### PR TITLE
Disable `docCache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # graphql-tag
+
+## ⚠️ NOTICE
+This is a modified version of `graphql-tag` that removes the `docCache` as we don't use it. **DO NOT USE**.
+
 [![npm version](https://badge.fury.io/js/graphql-tag.svg)](https://badge.fury.io/js/graphql-tag)
 [![Build Status](https://travis-ci.org/apollographql/graphql-tag.svg?branch=master)](https://travis-ci.org/apollographql/graphql-tag)
 [![Get on Slack](https://img.shields.io/badge/slack-join-orange.svg)](http://www.apollodata.com/#slack)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,6 @@ import {
   Location,
 } from 'graphql/language/ast';
 
-// A map docString -> graphql document
-const docCache = new Map<string, DocumentNode>();
-
 // A map fragmentName -> [normalized source]
 const fragmentSourceMap = new Map<string, Set<string>>();
 
@@ -91,23 +88,10 @@ function stripLoc(doc: DocumentNode) {
 }
 
 function parseDocument(source: string) {
-  var cacheKey = normalize(source);
-  if (!docCache.has(cacheKey)) {
-    const parsed = parse(source, {
-      experimentalFragmentVariables,
-      allowLegacyFragmentVariables: experimentalFragmentVariables,
-    } as any);
-    if (!parsed || parsed.kind !== 'Document') {
-      throw new Error('Not a valid GraphQL document.');
-    }
-    docCache.set(
-      cacheKey,
-      // check that all "new" fragments inside the documents are consistent with
-      // existing fragments of the same name
-      stripLoc(processFragments(parsed)),
-    );
-  }
-  return docCache.get(cacheKey)!;
+  return stripLoc(processFragments(parse(source, {
+    experimentalFragmentVariables,
+    allowLegacyFragmentVariables: experimentalFragmentVariables,
+  } as any)));
 }
 
 // XXX This should eventually disallow arbitrary string interpolation, like Relay does
@@ -135,7 +119,6 @@ export function gql(
 }
 
 export function resetCaches() {
-  docCache.clear();
   fragmentSourceMap.clear();
 }
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -317,66 +317,6 @@ describe('gql', () => {
     });
   });
 
-  it('returns the same object for the same query', () => {
-    assert.isTrue(gql`{ sameQuery }` === gql`{ sameQuery }`);
-  });
-
-  it('returns the same object for the same query, even with whitespace differences', () => {
-    assert.isTrue(gql`{ sameQuery }` === gql`  { sameQuery,   }`);
-  });
-
-  const fragmentAst = gql`
-  fragment UserFragment on User {
-    firstName
-    lastName
-  }
-`;
-
-  it('returns the same object for the same fragment', () => {
-    assert.isTrue(gql`fragment same on Same { sameQuery }` ===
-      gql`fragment same on Same { sameQuery }`);
-  });
-
-  it('returns the same object for the same document with substitution', () => {
-    // We know that calling `gql` on a fragment string will always return
-    // the same document, so we can reuse `fragmentAst`
-    assert.isTrue(gql`{ ...UserFragment } ${fragmentAst}` ===
-      gql`{ ...UserFragment } ${fragmentAst}`);
-  });
-
-  it('can reference a fragment that references as fragment', () => {
-    const secondFragmentAst = gql`
-      fragment SecondUserFragment on User {
-        ...UserFragment
-      }
-      ${fragmentAst}
-    `;
-
-    const ast = gql`
-      {
-        user(id: 5) {
-          ...SecondUserFragment
-        }
-      }
-      ${secondFragmentAst}
-    `;
-
-    assert.deepEqual(ast, gql`
-      {
-        user(id: 5) {
-          ...SecondUserFragment
-        }
-      }
-      fragment SecondUserFragment on User {
-        ...UserFragment
-      }
-      fragment UserFragment on User {
-        firstName
-        lastName
-      }
-    `);
-  });
-
   describe('fragment warnings', () => {
     let warnings = [];
     const oldConsoleWarn = console.warn;
@@ -395,14 +335,6 @@ describe('gql', () => {
 
       assert.isFalse(frag1 === frag2);
       assert.equal(warnings.length, 1);
-    });
-
-    it('does not warn if you use the same fragment name for the same fragment', () => {
-      const frag1 = gql`fragment TestDifferent on Bar { fieldOne }`;
-      const frag2 = gql`fragment TestDifferent on Bar { fieldOne }`;
-
-      assert.isTrue(frag1 === frag2);
-      assert.equal(warnings.length, 0);
     });
 
     it('does not warn if you use the same embedded fragment in two different queries', () => {


### PR DESCRIPTION
We don't use it and we want to avoid unnecessary memory leaks and/or scheduled cleanups.